### PR TITLE
fix-oauth

### DIFF
--- a/lib/heroics/client.rb
+++ b/lib/heroics/client.rb
@@ -70,8 +70,7 @@ module Heroics
   #     is no caching.
   # @return [Client] A client with resources and links from the JSON schema.
   def self.oauth_client_from_schema(oauth_token, schema, url, options={})
-    encoded_token = Base64.strict_encode64(":#{oauth_token}")
-    authorization = "Bearer #{encoded_token}"
+    authorization = "Bearer #{oauth_token}"
     # Don't mutate user-supplied data.
     options = Marshal.load(Marshal.dump(options))
     if !options.has_key?(:default_headers)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -147,7 +147,7 @@ class OAuthClientFromSchemaTest < MiniTest::Unit::TestCase
     body = {'Hello' => 'World!'}
     Excon.stub(method: :get) do |request|
       assert_equal(
-        'Bearer OmM1NWVmMGQ4LTQwYjYtNDc1OS1iMWJmLTRhNmY5NDE5MGE2Ng==',
+        'Bearer c55ef0d8-40b6-4759-b1bf-4a6f94190a66',
         request[:headers]['Authorization'])
       Excon.stubs.pop
       {status: 200, headers: {'Content-Type' => 'application/json'},
@@ -169,7 +169,7 @@ class OAuthClientFromSchemaTest < MiniTest::Unit::TestCase
       assert_equal('application/vnd.heroku+json; version=3',
                    request[:headers]['Accept'])
       assert_equal(
-        'Bearer OmM1NWVmMGQ4LTQwYjYtNDc1OS1iMWJmLTRhNmY5NDE5MGE2Ng==',
+        'Bearer c55ef0d8-40b6-4759-b1bf-4a6f94190a66',
         request[:headers]['Authorization'])
       Excon.stubs.pop
       {status: 200, headers: {'Content-Type' => 'application/json'},


### PR DESCRIPTION
- OAuth tokens are now correctly passed using Bearer authentication in
  plaintext without being base64 encoded and without a precending
  colon.
