### PR TITLE
Don't double nest options in options

### DIFF
--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -27,8 +27,8 @@ module <%= @module_name %>
     end
     cache = <%= @cache %>
     options = {
-      options: {default_headers: default_headers,
-                cache: cache}
+      default_headers: default_headers,
+                cache: cache
     }
     client = Heroics.client_from_schema(SCHEMA, url.to_s, options)
     Client.new(client)
@@ -49,8 +49,8 @@ module <%= @module_name %>
     end
     cache = <%= @cache %>
     options = {
-      options: {default_headers: default_headers,
-                cache: cache}
+      default_headers: default_headers,
+                cache: cache
     }
     client = Heroics.client_from_schema(oauth_token, SCHEMA, url, options)
     Client.new(client)


### PR DESCRIPTION
I've noticed that any headers that get passed into the generated `client_from_x` style methods were not included the headers specified.  It seems that this is because Heroics is passing in `options[:options]` rather than just `options`.

This commit removes that doubling up.

(NB, I have three tests failing locally, but these are failing with and without this commit)
