### PR TITLE
Fix config var end point generations

### DIFF
--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -246,7 +246,6 @@ module Heroics
     #   that represent parameters to be injected into the link URL.
     def resolve_parameter_details(parameters)
       properties = @schema['definitions'][@resource_name]['properties']
-      return [] if properties.nil?
 
       # URI decode parameters and strip the leading '{(' and trailing ')}'.
       parameters = parameters.map { |parameter| URI.unescape(parameter[2..-3]) }


### PR DESCRIPTION
Links on resources without properties like "config vars" in the Heroku
platform schema are currently being generated without parameters, even if
they specify that they have parameters in their `href`.

e.g.

``` ruby
 class ConfigVar
   def initialize(client)
     @client = client
   end

    # Get config-vars for app.
   def info()
     @client.config_var.info()
   end

    # Update config-vars for app. You can update existing config-vars by
setting them again, and remove by setting it to `NULL`.
   #
   # @param body: the object to pass as the request payload
   def update(body)
     @client.config_var.update(body)
   end
 end
```

This pull removes a check on the `properties` array so that these links can
be properly generated.

``` ruby
 class ConfigVar
   def initialize(client)
     @client = client
   end

    # Get config-vars for app.
   #
   # @param app_id_or_app_name: unique identifier of app or unique name of
app
   def info(app_id_or_app_name)
     @client.config_var.info(app_id_or_app_name)
   end

    # Update config-vars for app. You can update existing config-vars by
setting them again, and remove by setting it to `NULL`.
   #
   # @param app_id_or_app_name: unique identifier of app or unique name of
app
   # @param body: the object to pass as the request payload
   def update(app_id_or_app_name, body)
     @client.config_var.update(app_id_or_app_name, body)
   end
 end
```
