### PR TITLE
Definitions without resource names

### DIFF
--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -367,7 +367,11 @@ module Heroics
     # for use in a function signature.
     def name
       @parameters.map do |parameter|
-        "#{@resource_name}_#{parameter.name}"
+        if parameter.resource_name
+          parameter.name
+        else
+          "#{@resource_name}_#{parameter.name}"
+        end
       end.join('_or_')
     end
 

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -134,7 +134,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
     parameters = link.parameter_details
     assert_equal(1, parameters.length)
     parameter = parameters[0]
-    assert_equal('resource_resource_uuid_field_or_resource_resource_email_field', parameter.name)
+    assert_equal('resource_uuid_field_or_resource_email_field', parameter.name)
     assert_equal('A sample UUID field or A sample email address field',
                  parameter.description)
   end


### PR DESCRIPTION
- `ParameterChoice` generates a name with it's resource name
- `Parameter` is given the resource name only if it exists
- `Parameter` will not use nil resource names
