### PR TITLE
Hash#hash isn't 0 for the empty hash in Ruby 2.0+

### DIFF
--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -270,8 +270,9 @@ class LinkTest < MiniTest::Unit::TestCase
       {status: 200}
     end
 
+    headers = {}
     cache = Moneta.new(:Memory)
-    cache['etag:/resource:0'] = 'etag-contents'
+    cache["etag:/resource:#{headers.hash}"] = 'etag-contents'
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
     link = Heroics::Link.new('https://example.com',
                              schema.resource('resource').link('list'),
@@ -306,9 +307,10 @@ class LinkTest < MiniTest::Unit::TestCase
       {status: 304, headers: {'Content-Type' => 'application/json'}}
     end
 
+    headers = {}
     cache = Moneta.new(:Memory)
-    cache['etag:/resource:0'] = 'etag-contents'
-    cache['data:/resource:0'] = MultiJson.dump(body)
+    cache["etag:/resource:#{headers.hash}"] = 'etag-contents'
+    cache["data:/resource:#{headers.hash}"] = MultiJson.dump(body)
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
     link = Heroics::Link.new('https://example.com',
                              schema.resource('resource').link('list'),


### PR DESCRIPTION
This was an assumption in the tests for Link which cause the tests to
fail on Ruby 2.0+