### PR TITLE
Compatibility for complex JSON Content-Types

### DIFF
--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -63,7 +63,7 @@ module Heroics
       content_type = response.headers['Content-Type']
       if response.status == 304
         MultiJson.load(@cache["data:#{cache_key}"])
-      elsif content_type && content_type.include?('application/json')
+      elsif content_type && content_type =~ /application\/.*json/
         etag = response.headers['ETag']
         if etag
           @cache["etag:#{cache_key}"] = etag

--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -139,7 +139,7 @@ module Heroics
       case content_type
       when 'application/x-www-form-urlencoded'
         URI.encode_www_form(body)
-      when 'application/json'
+      when /application\/.*json/
         MultiJson.dump(body)
       end
     end

--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -197,7 +197,7 @@ class LinkTest < MiniTest::Unit::TestCase
       assert_equal('/resource', request[:path])
       Excon.stubs.pop
       {status: 200,
-       headers: {'Content-Type' => 'application/json;charset=utf-8'},
+       headers: {'Content-Type' => 'application/vnd.api+json;charset=utf-8'},
        body: MultiJson.dump(body)}
     end
 


### PR DESCRIPTION
This adds support for more complex JSON Content-Types than
'application/json'. In particular, this will allow support for types
such as 'application/vnd.api+json'.