### PR TITLE
204 No Content responses are successful

### DIFF
--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -59,7 +59,7 @@ module Heroics
       connection = Excon.new(@root_url)
       response = connection.request(method: @link_schema.method, path: path,
                                     headers: headers, body: body,
-                                    expects: [200, 201, 202, 206, 304])
+                                    expects: [200, 201, 202, 204, 206, 304])
       content_type = response.headers['Content-Type']
       if response.status == 304
         MultiJson.load(@cache["data:#{cache_key}"])

--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -223,6 +223,20 @@ class LinkTest < MiniTest::Unit::TestCase
     assert_equal(body, link.run)
   end
 
+  # Link.run considers HTTP 204 No Content responses as successful.
+  def test_run_with_no_content_response
+    Excon.stub(method: :delete) do |request|
+      assert_equal("/resource/2013-01-01T08:00:00Z", request[:path])
+      Excon.stubs.pop
+      {status: 204, body: ''}
+    end
+
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = Heroics::Link.new('https://example.com',
+                             schema.resource('resource').link('delete'))
+    assert_equal(nil, link.run(Time.parse('2013-01-01 00:00:00-0800')))
+  end
+
   # Link.run raises an Excon error if anything other than a 200 or 201 HTTP
   # status code was returned by the server.
   def test_run_with_failed_request


### PR DESCRIPTION
I'm writing an API that adheres to the JSON API spec, which requires that 204 No Content is returned in response to successful `DELETE` requests. This adds that response code to the list of acceptable responses.