### PR TITLE
escape especial URL characters in link parameters

### DIFF
--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -323,7 +323,8 @@ module Heroics
     # @param [Fixnum,String,TrueClass,FalseClass,Time] The parameter to format.
     # @return [String] The formatted parameter.
     def format_parameter(parameter)
-      parameter.instance_of?(Time) ? iso_format(parameter) : parameter.to_s
+      formatted_parameter = parameter.instance_of?(Time) ? iso_format(parameter) : parameter.to_s
+      URI.escape formatted_parameter
     end
 
     # Convert a time to an ISO 8601 combined data and time format.

--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -38,6 +38,20 @@ class LinkTest < MiniTest::Unit::TestCase
     assert_equal(nil, link.run('44724831-bf66-4bc2-865f-e2c4c2b14c78'))
   end
 
+  # Link.run URL-escapes special characters in parameters.
+  def test_run_with_parameters_needing_escaping
+    Excon.stub(method: :get) do |request|
+      assert_equal('/resource/foo%23bar', request[:path])
+      Excon.stubs.pop
+      {status: 200, body: ''}
+    end
+
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = Heroics::Link.new('https://example.com',
+                             schema.resource('resource').link('info'))
+    assert_equal(nil, link.run('foo#bar'))
+  end
+
   # Link.run converts Time parameters to UTC before sending them to the
   # server.
   def test_run_converts_time_parameters_to_utc

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -167,6 +167,14 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
                  link.format_path(['44724831-bf66-4bc2-865f-e2c4c2b14c78']))
   end
 
+  # LinkSchema.format_path escapes special URL characters in parameters.
+  def test_format_path_with_illegal_literals
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = schema.resource('resource').link('info')
+    assert_equal(['/resource/foobar%25', nil],
+                 link.format_path(['foobar%']))
+  end
+
   # LinkSchema.format_path correctly returns a parameter as a body if a path
   # doesn't have any parameters.
   def test_format_path_with_body


### PR DESCRIPTION
so I had a request with an id that had a `%` in it, and the generated URL didn't escape it, causing Excon to barf on it:

```
Excon::Errors::BadRequest: Expected([200, 201, 202, 206, 304]) <=> Actual(400 Bad Request)

from /usr/local/lib/ruby/gems/2.2.0/gems/excon-0.44.3/lib/excon/middlewares/expects.rb:6:in `response_call'
from /usr/local/lib/ruby/gems/2.2.0/gems/excon-0.44.3/lib/excon/middlewares/response_parser.rb:8:in `response_call'
from /usr/local/lib/ruby/gems/2.2.0/gems/excon-0.44.3/lib/excon/connection.rb:372:in `response'
from /usr/local/lib/ruby/gems/2.2.0/gems/excon-0.44.3/lib/excon/connection.rb:236:in `request'
from /usr/local/lib/ruby/gems/2.2.0/gems/heroics-0.0.12/lib/heroics/link.rb:60:in `run'
from /usr/local/lib/ruby/gems/2.2.0/gems/heroics-0.0.12/lib/heroics/resource.rb:27:in `method_missing'
from /usr/local/lib/ruby/gems/2.2.0/gems/support-api-0.5.5/lib/support-api/client.rb:352:in `find'
from (irb):8
from /usr/local/opt/ruby/bin/irb:11:in `<main>'
```

This fixes that, albeit I'm not entirely sure I chose the right place to do the escaping, conceptually speaking.