### PR TITLE
excon-options-jkakar

### DIFF
--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -12,11 +12,13 @@ module Heroics
     #     request made by the client.  Default is no custom headers.
     #   - cache: Optionally, a Moneta-compatible cache to store ETags.
     #     Default is no caching.
+    #   - excon_options: Optionally, the options hash to pass to Excon.
     def initialize(url, link_schema, options={})
       @root_url, @path_prefix = unpack_url(url)
       @link_schema = link_schema
       @default_headers = options[:default_headers] || {}
       @cache = options[:cache] || Moneta.new(:Null)
+      @excon_options = options[:excon_options] || {}
     end
 
     # Make a request to the server.
@@ -56,7 +58,7 @@ module Heroics
         headers = headers.merge({'If-None-Match' => etag}) if etag
       end
 
-      connection = Excon.new(@root_url)
+      connection = Excon.new(@root_url, @excon_options)
       response = connection.request(method: @link_schema.method, path: path,
                                     headers: headers, body: body,
                                     expects: [200, 201, 202, 204, 206, 304])

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -167,6 +167,7 @@ class OAuthClientFromSchemaTest < MiniTest::Unit::TestCase
   def test_oauth_client_from_schema_with_options
     body = {'Hello' => 'World!'}
     Excon.stub(method: :get) do |request|
+      assert_equal('1', request[:headers]['Excon-Option'])
       assert_equal('application/vnd.heroku+json; version=3',
                    request[:headers]['Accept'])
       assert_equal(
@@ -179,7 +180,8 @@ class OAuthClientFromSchemaTest < MiniTest::Unit::TestCase
 
     oauth_token = 'c55ef0d8-40b6-4759-b1bf-4a6f94190a66'
     options = {
-      default_headers: {'Accept' => 'application/vnd.heroku+json; version=3'}}
+      default_headers: {'Accept' => 'application/vnd.heroku+json; version=3'},
+      excon_options: {headers: {'Excon-Option' => '1'}}}
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
     client = Heroics.oauth_client_from_schema(oauth_token, schema,
                                               'https://example.com', options)


### PR DESCRIPTION
Allow arbitrary Excon options to be passed to the connection when
making requests.

/cc @geemus I don't really like directly exposing Excon in the
generated client API, but I also don't want to proxy every option
Excon takes.  What do you think about this?
