### PR TITLE
Add thread_safe_sockets option to Excon connection

### DIFF
--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -56,7 +56,7 @@ module Heroics
         headers = headers.merge({'If-None-Match' => etag}) if etag
       end
 
-      connection = Excon.new(@root_url)
+      connection = Excon.new(@root_url, thread_safe_sockets: true)
       response = connection.request(method: @link_schema.method, path: path,
                                     headers: headers, body: body,
                                     expects: [200, 201, 202, 204, 206, 304])


### PR DESCRIPTION
This is probably a good idea as a default in that it's a little safer
for a general purpose program (which is especially important given that
heroics/platform-api do not allow their users to customize a connection in
any way).