### PR TITLE
Fix default option for cache and url

### DIFF
--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -66,8 +66,8 @@ module <%= @module_name %>
     if options[:default_headers]
       final_options[:default_headers].merge!(options[:default_headers])
     end
-    final_options[:cache] = options[:cache] if options[:cache]
-    final_options[:url] = options[:url] || <%= @cache %>
+    final_options[:cache] = options[:cache] || <%= @cache %>
+    final_options[:url] = options[:url] if options[:url]
     final_options[:user] = options[:user] if options[:user]
     final_options
   end


### PR DESCRIPTION
In the previous change, a bug was introduced, because `@cache` was mapped to the `:url` option instead of `:cache`.