### PR TITLE
make body param optional

### DIFF
--- a/lib/heroics/client_generator.rb
+++ b/lib/heroics/client_generator.rb
@@ -80,8 +80,12 @@ module Heroics
       end
     end
 
-    # The list of parameters to render in generated source code for the method
-    # signature for the link.
+    # list of parameters for method signature, body is optional
+    def method_signature
+      @parameters.map { |info| info.name == 'body' ? "body = {}" : info.name }.join(', ')
+    end
+
+    # list of parameters to pass along from method signature to client calls
     def parameter_names
       @parameters.map { |info| info.name }.join(', ')
     end

--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -124,7 +124,7 @@ module <%= @module_name %>
     # @param <%= parameter.name %>: <%= parameter.description %>
     <% end %>
     <% end %>
-    def <%= link.name %>(<%= link.parameter_names %>)
+    def <%= link.name %>(<%= link.method_signature %>)
       @client.<%= resource.name %>.<%= link.name %>(<%= link.parameter_names %>)
     end
     <% end %>


### PR DESCRIPTION
see also @heroku/platform-api#45

@jkakar I think this should be fairly safe, but would appreciate you confirming. Basically this allows stuff (like log session create) that has no require params to "just work". For stuff that does require params, it would technically allow you to call it without, but that should return a clear error telling you what to fix I think/hope. Let me know what you think.

