### PR TITLE
Remove non-identifier characters from ruby_names

### DIFF
--- a/lib/heroics/naming.rb
+++ b/lib/heroics/naming.rb
@@ -3,10 +3,11 @@ module Heroics
   # Process a name to make it suitable for use as a Ruby method name.
   #
   # @param name [String] The name to process.
-  # @return [String] The new name with capitals converted to lowercase, and
-  #   dashes and spaces converted to underscores.
+  # @return [String] The new name with capitals converted to lowercase,
+  #   dashes and spaces converted to underscores, and non-identifier 
+  #   characters removed.
   def self.ruby_name(name)
-    name.downcase.gsub(/[- ]/, '_')
+    name.downcase.gsub(/[- ]/, '_').gsub(/\W/, '')
   end
 
   # Process a name to make it suitable for use as a pretty command name.

--- a/lib/heroics/naming.rb
+++ b/lib/heroics/naming.rb
@@ -6,8 +6,11 @@ module Heroics
   # @return [String] The new name with capitals converted to lowercase,
   #   dashes and spaces converted to underscores, and non-identifier 
   #   characters removed.
+  # @raise [SchemaError] Raised if the name contains invalid characters.
   def self.ruby_name(name)
-    name.downcase.gsub(/[- ]/, '_').gsub(/\W/, '')
+    ruby_name = name.downcase.gsub(/[- ]/, '_')
+    raise SchemaError.new("Name '#{name}' converts to invalid Ruby name '#{ruby_name}'.") if ruby_name =~ /\W/
+    ruby_name
   end
 
   # Process a name to make it suitable for use as a pretty command name.

--- a/test/naming_test.rb
+++ b/test/naming_test.rb
@@ -22,8 +22,11 @@ class RubyNameTest < MiniTest::Unit::TestCase
     assert_equal('spaced_name', Heroics.ruby_name('spaced name'))
   end
   
-  def test_ruby_name_with_parens
-    assert_equal('parenthesized_name', Heroics.ruby_name('Parenthesized (Name)'))
+  def test_ruby_name_with_invalid_chars
+    error = assert_raises Heroics::SchemaError do
+      Heroics.ruby_name('Name (Parenthetical)')
+    end
+    assert_equal("Name 'Name (Parenthetical)' converts to invalid Ruby name 'name_(parenthetical)'.", error.message)
   end
 end
 

--- a/test/naming_test.rb
+++ b/test/naming_test.rb
@@ -21,6 +21,10 @@ class RubyNameTest < MiniTest::Unit::TestCase
   def test_ruby_name_with_spaces
     assert_equal('spaced_name', Heroics.ruby_name('spaced name'))
   end
+  
+  def test_ruby_name_with_parens
+    assert_equal('parenthesized_name', Heroics.ruby_name('Parenthesized (Name)'))
+  end
 end
 
 class PrettyNameTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
If `ruby_name` is passed a string with characters that are not dashes, spaces, or in `\w`, this patch will remove those characters entirely from the string.

To be clear, I'm not sure this is the design we want—think of this as a way of prompting discussion.

I've put this in because the Heroku API schema currently has a link with the title "Create (Deprecated)". Heroics was trying to expose this as a method called `create_(deprecated)`, which is obviously invalid. With this patch, it instead becomes `create_deprecated`, which is probably the best mapping we can expect.

(There are other problems with the Platform API schema—some links are missing titles entirely—but I have a ticket filed with Heroku to get that fixed.)