### PR TITLE
Allow ruby names replacement patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ end
 
 #### Optional configuration
 
-`config.headers` and `config.cache_path` are optional, but all other config shown above is required.
+`base_url`, `module_name`, and `schema_filepath` are required for a proper configuration.
+
+The following keys are optional:
+
+* `headers`
+* `cache_path`
+* `ruby_name_replacements` a hash of replacement patterns for converting endpoint paths to Ruby method names, such as:
+> { /[\s-]+/ => '_' }
 
 For further details on config file usage, see the `example/` directory in this repo.
 

--- a/lib/heroics/configuration.rb
+++ b/lib/heroics/configuration.rb
@@ -3,16 +3,27 @@
 module Heroics
   # Attempts to load configuration, provides defaults, and provide helpers to access that data
   class Configuration
-    attr_reader :base_url, :cache_path, :module_name, :schema, :options
+    attr_reader :base_url,
+      :cache_path,
+      :module_name,
+      :schema,
+      :ruby_name_replacement_patterns,
+      :options
 
     def self.defaults
       @defaults ||= Configuration.new
+    end
+
+    def self.restore_defaults
+      @defaults = Configuration.new
     end
 
     def initialize
       @options = {}
       @options[:cache] = 'Moneta.new(:Memory)'
       @options[:default_headers] = {}
+
+      @ruby_name_replacement_patterns = { /[\s-]+/ => '_' }
 
       yield self if block_given?
     end
@@ -40,6 +51,11 @@ module Heroics
     def headers=(headers)
       raise "Must provide a hash of headers" unless headers.is_a?(Hash)
       @options[:default_headers] = headers
+    end
+
+    def ruby_name_replacement_patterns=(patterns)
+      raise "Must provide a hash of replacements" unless patterns.is_a?(Hash)
+      @ruby_name_replacement_patterns = patterns
     end
   end
 end

--- a/lib/heroics/naming.rb
+++ b/lib/heroics/naming.rb
@@ -6,7 +6,11 @@ module Heroics
   # @return [String] The new name with capitals converted to lowercase, and
   #   dashes and spaces converted to underscores.
   def self.ruby_name(name)
-    name.downcase.gsub(/[- ]/, '_')
+    patterns = Heroics::Configuration.defaults.ruby_name_replacement_patterns
+
+    patterns.reduce(name.downcase) do |memo, (regex, replacement)|
+      memo.gsub(regex, replacement)
+    end
   end
 
   # Process a name to make it suitable for use as a pretty command name.

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require 'heroics'
 require 'heroics/configuration'
 
 class ConfigurationTest < MiniTest::Unit::TestCase
@@ -9,5 +9,38 @@ class ConfigurationTest < MiniTest::Unit::TestCase
     assert_equal(yielded_object, config)
   end
 
+  def test_default_ruby_name_replacement_patterns
+    # No configuration set up beforehand
 
+    assert(Heroics::Configuration.defaults.ruby_name_replacement_patterns.is_a?(Hash))
+    assert_equal(Heroics::Configuration.defaults.ruby_name_replacement_patterns, { /[\s-]+/ => '_' })
+  end
+
+  def test_configuring_ruby_name_replacement_patterns
+    patterns =  { /\s+/ => '_', /-/ => '' }
+
+    Heroics.default_configuration do |c|
+      c.ruby_name_replacement_patterns = patterns
+    end
+
+    assert(Heroics::Configuration.defaults.ruby_name_replacement_patterns.is_a?(Hash))
+    assert_equal(Heroics::Configuration.defaults.ruby_name_replacement_patterns, patterns)
+
+    Heroics::Configuration.restore_defaults
+  end
+
+  def test_restore_defaults_class_method
+    patterns = { /\W+/ => '-' }
+    Heroics.default_configuration do |c|
+      c.ruby_name_replacement_patterns = patterns
+    end
+
+    assert_equal(Heroics::Configuration.defaults.ruby_name_replacement_patterns, patterns)
+
+    Heroics::Configuration.restore_defaults
+
+    refute_equal(Heroics::Configuration.defaults.ruby_name_replacement_patterns, patterns)
+  end
+
+  MiniTest::Unit.after_tests { |b| Heroics.default_configuration }
 end

--- a/test/naming_test.rb
+++ b/test/naming_test.rb
@@ -2,6 +2,11 @@
 require 'helper'
 
 class RubyNameTest < MiniTest::Unit::TestCase
+  # Given default replacement patterns on Heroics::Configuration:
+  def setup
+    Heroics.default_configuration
+  end
+
   # ruby_name is a no-op when an empty string is provided.
   def test_ruby_name_with_empty_name
     assert_equal('', Heroics.ruby_name(''))


### PR DESCRIPTION
This includes changes from #78 and makes it work with configurable replacement patterns in the Configuration file. (By default, it does the same replacements as @brentdax was adding in #78.) 

We needed to be able to configure the ruby_name replacement patterns for our own platform-api gem.