### PR TITLE
Document how not to set up config for cache_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Heroics.default_configuration do |config|
   config.schema_filepath = 'schema.json'
 
   config.headers = { 'Accept' => 'application/vnd.example+json; version=1' }
-  config.cache_path = "#{Dir.home}/.heroics/example"
+
+  # Note: Don't use doublequotes below -- we want to interpolate at runtime,
+  # not when the client is generated
+  config.cache_path = '#{Dir.home}/.heroics/example'
 end
 ```
 

--- a/example/example-client-configuration.rb
+++ b/example/example-client-configuration.rb
@@ -7,5 +7,7 @@ Heroics.default_configuration do |config|
   config.schema_filepath = 'schema.json'
 
   config.headers = { 'Accept' => 'application/vnd.example+json; version=1' }
-  config.cache_path = "#{Dir.home}/.heroics/example"
+  # Note: Don't use doublequotes below -- we want to interpolate at runtime,
+  # not when the client is generated
+  config.cache_path = '#{Dir.home}/.heroics/example'
 end


### PR DESCRIPTION
We want this to interpolate later when the client class is running in the client gem, not when we interpret the `configuration.rb` file. So don't use double quotes up front.

This is a little tricky, but it seemed better than trying to get clever about how people specify a path with interpolation or a path relative to the home directory, here. (Not everyone may want their client gem to use a path relative to the home directory for the cache_path, either.)