### PR TITLE
Fix resource lists to match auto-generated method names

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'turn'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'pry'
 
   spec.add_dependency 'erubis', '~> 2.0'
   spec.add_dependency 'excon'

--- a/lib/heroics/client.rb
+++ b/lib/heroics/client.rb
@@ -8,7 +8,8 @@ module Heroics
     #   to resources.
     # @param url [String] The URL used by this client.
     def initialize(resources, url)
-      @resources = resources
+      # Transform resource keys via the ruby_name replacement semantics
+      @resources = Hash[resources.map{ |k, v| [Heroics.ruby_name(k), v] }]
       @url = url
     end
 
@@ -21,8 +22,9 @@ module Heroics
       name = name.to_s
       resource = @resources[name]
       if resource.nil?
-        # Try substituting underscores for dashes
-        name = name.to_s.gsub('_', '-')
+        # Find the name using the same ruby_name replacement semantics as when
+        # we set up the @resources hash
+        name = Heroics.ruby_name(name)
         resource = @resources[name]
         if resource.nil?
           raise NoMethodError.new("undefined method `#{name}' for #{to_s}")

--- a/lib/heroics/version.rb
+++ b/lib/heroics/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Heroics
-  VERSION = '0.0.20'
+  VERSION = '0.0.21'
 end


### PR DESCRIPTION
We need to ensure we look in the schema resource lists for the resource under the same name we stubbed out for a method.