### PR TITLE
Fix off-by-one error in LinkSchema#format_path

### DIFF
--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -204,7 +204,7 @@ module Heroics
                                 "(#{parameters.size} for #{parameter_size})")
       end
 
-      (0..parameter_size).each do |i|
+      (0...parameter_size).each do |i|
         path = path.sub(PARAMETER_REGEX, format_parameter(parameters[i]))
       end
       body = parameters.slice(parameter_size)

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -196,6 +196,24 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
                                    {'new' => 'resource'}]))
   end
 
+  # LinkSchema.format_path only attempts to format path parameters. The body (if
+  # supplied), is *not* passed to LinkSchema#format_parameter
+  def test_format_path_only_formats_path_parameters
+    param = '44724831-bf66-4bc2-865f-e2c4c2b14c78'
+    body = { 'new' => 'resource' }
+    formatted_values = []
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = schema.resource('resource').link('update')
+    link.singleton_class.send(:alias_method, :orig_format_parameter, :format_parameter)
+    link.define_singleton_method(:format_parameter) do |value|
+      formatted_values.push(value)
+      orig_format_parameter(value)
+    end
+
+    assert_equal(["/resource/#{param}", body], link.format_path([param, body]))
+    assert_equal([param], formatted_values)
+  end
+
   # LinkSchema.format_path raises an ArgumentError if too few parameters are
   # provided
   def test_format_path_with_too_few_parameters


### PR DESCRIPTION
A bug in a model class' `to_s` method (which returned nil) revealed that `LinkSchema#format_path` is attempting to process the body as a parameter. Since there are no further matches for `PARAMETER_REGEX`, the value is discarded. I suppose that's how this error lay dormant for so long!