### PR TITLE
handle multiline schema and link description text

### DIFF
--- a/lib/heroics/command.rb
+++ b/lib/heroics/command.rb
@@ -22,7 +22,7 @@ module Heroics
 
     # The command description.
     def description
-      @link_schema.description
+      @link_schema.description.lines.first.chomp
     end
 
     # Write usage information to the output stream.

--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -91,7 +91,9 @@ module <%= @module_name %>
 
   private_class_method :default_options, :custom_options
 
-  # <%= @description %>
+  <% @description.each_line do |desc| %>
+    <%= "# #{desc}" %>
+  <% end %>
   class Client
     def initialize(client)
       @client = client
@@ -110,14 +112,18 @@ module <%= @module_name %>
   private
   <% for resource in @resources %>
 
-  # <%= resource.description %>
+  <% resource.description.each_line do |desc| %>
+    <%= "# #{desc}" %>
+  <% end %>
   class <%= resource.class_name %>
     def initialize(client)
       @client = client
     end
     <% for link in resource.links %>
 
-    # <%= link.description %>
+    <% link.description.each_line do |desc| %>
+      <%= "# #{desc}" %>
+    <% end %>
     <% unless link.parameters.empty? %>
     #
     <% for parameter in link.parameters %>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -25,7 +25,7 @@ end
 
 # A simple JSON schema for testing purposes.
 SAMPLE_SCHEMA = {
-  'description' => 'Sample schema for use in tests.',
+  'description' => "Sample schema for use in tests\nThis description has two lines",
   'definitions' => {
     'resource' => {
       'description' => 'A sample resource to use in tests.',
@@ -93,7 +93,7 @@ SAMPLE_SCHEMA = {
       },
 
       'links' => [
-        {'description' => 'Show all sample resources',
+        {'description' => "Show all sample resources\nThis is another documentation line",
          'href'        => '/resource',
          'method'      => 'GET',
          'rel'         => 'instances',

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -7,7 +7,8 @@ class SchemaTest < MiniTest::Unit::TestCase
   def test_to_s
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
     assert_equal(
-      '#<Heroics::Schema description="Sample schema for use in tests.">',
+      '#<Heroics::Schema description="Sample schema for use in tests
+This description has two lines">',
       schema.to_s)
   end
 
@@ -77,7 +78,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
   # LinkSchema.description returns the link description.
   def test_description
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
-    assert_equal('Show all sample resources',
+    assert_equal("Show all sample resources\nThis is another documentation line",
                  schema.resource('resource').link('list').description)
   end
 


### PR DESCRIPTION
This adds support for multi-line strings in the top-level and per-link descriptions. Adding support for individual link params didn't fit in very well, and I didn't (yet) need that functionality.

This feels a little fragile, and I'm not sure what the right answer is for the automatically generated `cli` help output. I chose to keep it tidy, and only print the first line. Thoughts?