### PR TITLE
Raise on duplicate link names

### DIFF
--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -66,7 +66,7 @@ module Heroics
         .map(&:first)
       if !duplicate_names.empty?
         raise SchemaError.new("Duplicate link names " +
-                              "'#{duplicate_names.join(', ')}'.")
+                              "'#{duplicate_names.join("', '")}'.")
       end
 
       @links = Hash[link_schema.each_with_index.map do |link, link_index|

--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -60,6 +60,15 @@ module Heroics
       @name = name
       link_schema = schema['definitions'][name]['links'] || []
 
+      duplicate_names = link_schema
+        .group_by { |link| Heroics.ruby_name(link['title']) }
+        .select { |k, v| v.size > 1 }
+        .map(&:first)
+      if !duplicate_names.empty?
+        raise SchemaError.new("Duplicate link names " +
+                              "'#{duplicate_names.join(', ')}'.")
+      end
+
       @links = Hash[link_schema.each_with_index.map do |link, link_index|
                       link_name = Heroics.ruby_name(link['title'])
                       [link_name, LinkSchema.new(schema, name, link_index)]

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -58,6 +58,17 @@ class ResourceSchemaTest < MiniTest::Unit::TestCase
       ['list', 'info', 'identify_resource', 'create', 'submit', 'update', 'delete'],
       schema.resource('resource').links.map { |link| link.name })
   end
+
+  def test_duplicate_links
+    duplicate_links_schema = Marshal.load(Marshal.dump(SAMPLE_SCHEMA))
+    link = duplicate_links_schema['definitions']['resource']['links'].first
+    duplicate_links_schema['definitions']['resource']['links'] = [link, link]
+
+    error = assert_raises Heroics::SchemaError do
+      Heroics::Schema.new(duplicate_links_schema)
+    end
+    assert_equal("Duplicate link names 'list'.", error.message)
+  end
 end
 
 class LinkSchemaTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
Currently if two links in the same definitions have the same title, Heroics will pick the latest one with the name. This change makes it so that Heroics will bail out of the client generation for ambiguous  schemas with an error `Duplicate link names 'list', 'info'`.

In the Heroku API schema we currently have a few misnamed endpoints that are conflicting for this reason.