### PR TITLE
:bug: fix dependency

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'minitest', '4.7.5'
-  spec.add_development_dependency 'moneta'
   spec.add_development_dependency 'netrc'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'turn'
@@ -32,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'erubis', '~> 2.0'
   spec.add_dependency 'excon'
   spec.add_dependency 'multi_json', '>= 1.9.2'
+  spec.add_dependency 'moneta'
 end

--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -9,6 +9,7 @@
 
 require 'heroics'
 require 'uri'
+require 'moneta'
 
 module <%= @module_name %>
   # Get a Client configured to use HTTP Basic or header-based authentication.


### PR DESCRIPTION
The heriocs generate code include Moneta gem.
(like this https://github.com/interagent/heroics/blob/master/example/lib/example-client/client.rb#L77 )

So always when we use heriocs's generated code we must install this gem.
But, gemspec setting is `add_development_dependency` so I change `add_dependency` and add `require' to generated code.

Or, we should support no cache option and don't generate above-mentioned line.
(If the user want to use Moneta, they add gem to thiers Gemfile. )