### PR TITLE
Add configurable rate throttling integration

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep('^(test|spec|features)/')
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '4.7.5'
   spec.add_development_dependency 'netrc'
   spec.add_development_dependency 'rake'

--- a/lib/heroics/configuration.rb
+++ b/lib/heroics/configuration.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 module Heroics
+
+  module NullRateLimit
+    def self.call
+      yield
+    end
+  end
+
   # Attempts to load configuration, provides defaults, and provide helpers to access that data
   class Configuration
     attr_reader :base_url,
@@ -22,7 +29,7 @@ module Heroics
       @options = {}
       @options[:cache] = 'Moneta.new(:Memory)'
       @options[:default_headers] = {}
-
+      @options[:rate_throttle] = NullRateLimit
       @ruby_name_replacement_patterns = { /[\s-]+/ => '_' }
 
       yield self if block_given?
@@ -57,5 +64,11 @@ module Heroics
       raise "Must provide a hash of replacements" unless patterns.is_a?(Hash)
       @ruby_name_replacement_patterns = patterns
     end
+
+    def rate_throttle=(rate_throttle)
+      @options[:rate_throttle] = rate_throttle
+    end
+
+
   end
 end

--- a/lib/heroics/configuration.rb
+++ b/lib/heroics/configuration.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Heroics
-
   module NullRateLimit
     def self.call
       yield
@@ -68,7 +67,5 @@ module Heroics
     def rate_throttle=(rate_throttle)
       @options[:rate_throttle] = rate_throttle
     end
-
-
   end
 end

--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -18,7 +18,7 @@ module Heroics
       @link_schema = link_schema
       @default_headers = options[:default_headers] || {}
       @cache = options[:cache] || {}
-      @rate_throttle = Heroics::Configuration.defaults.options[:rate_throttle]
+      @rate_throttle = options[:rate_throttle] || Heroics::Configuration.defaults.options[:rate_throttle]
     end
 
     # Make a request to the server.

--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -18,6 +18,7 @@ module Heroics
       @link_schema = link_schema
       @default_headers = options[:default_headers] || {}
       @cache = options[:cache] || {}
+      @rate_throttle = Heroics::Configuration.defaults.options[:rate_throttle]
     end
 
     # Make a request to the server.
@@ -108,7 +109,10 @@ module Heroics
         etag = @cache["etag:#{cache_key}"]
         options[:headers] = options[:headers].merge({'If-None-Match' => etag}) if etag
       end
-      response = connection.request(options)
+
+      response = @rate_throttle.call do
+        connection.request(options)
+      end
 
       if response.status == 304
         body = @cache["data:#{cache_key}"]

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -29,6 +29,18 @@ class ConfigurationTest < MiniTest::Unit::TestCase
     Heroics::Configuration.restore_defaults
   end
 
+  def test_configuring_rate_throttle
+    new_rate_throttle = lambda {}
+    Heroics.default_configuration do |c|
+      c.rate_throttle = new_rate_throttle
+    end
+
+    assert(Heroics::Configuration.defaults.options[:rate_throttle].is_a?(Proc))
+    assert_equal(Heroics::Configuration.defaults.options[:rate_throttle], new_rate_throttle)
+
+    Heroics::Configuration.restore_defaults
+  end
+
   def test_restore_defaults_class_method
     patterns = { /\W+/ => '-' }
     Heroics.default_configuration do |c|


### PR DESCRIPTION
API clients may be interacting with a server which implements rate limiting which will produce errors, rate throttling is a good way to gracefully handle this event. This isn't the rate throttling code, however it does allow clients to configure their own rate throttling logic.

For example in the PlatformAPI gem we can hook in this logic: https://github.com/schneems/rate-limit-gcra-client-demo. The goal of getting this behaviour into Heroics is to eventually introduce generic rate throttling into the PlatformAPI gem, though anyone who is writing a client can hook in and provide their own logic.

cc @schneems