### PR TITLE
Add status codes configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
+- Add status codes configuration (https://github.com/interagent/heroics/pull/96)
+
 ## 0.1.0
 
 - Introduced rate throttling integration point (https://github.com/interagent/heroics/pull/95)
-

--- a/lib/heroics/configuration.rb
+++ b/lib/heroics/configuration.rb
@@ -29,6 +29,7 @@ module Heroics
       @options[:cache] = 'Moneta.new(:Memory)'
       @options[:default_headers] = {}
       @options[:rate_throttle] = NullRateLimit
+      @options[:status_codes] = []
       @ruby_name_replacement_patterns = { /[\s-]+/ => '_' }
 
       yield self if block_given?
@@ -66,6 +67,10 @@ module Heroics
 
     def rate_throttle=(rate_throttle)
       @options[:rate_throttle] = rate_throttle
+    end
+
+    def acceptable_status_codes=(status_codes)
+      @options[:status_codes] = status_codes
     end
   end
 end

--- a/lib/heroics/link.rb
+++ b/lib/heroics/link.rb
@@ -19,6 +19,7 @@ module Heroics
       @default_headers = options[:default_headers] || {}
       @cache = options[:cache] || {}
       @rate_throttle = options[:rate_throttle] || Heroics::Configuration.defaults.options[:rate_throttle]
+      @status_codes = options[:status_codes] || Heroics::Configuration.defaults.options[:status_codes]
     end
 
     # Make a request to the server.
@@ -104,6 +105,9 @@ module Heroics
 
     def request_with_cache(connection, options)
       options[:expects] << 304
+      @status_codes.each do |code|
+        options[:expects] << code
+      end
       cache_key = "#{options[:path]}:#{options[:headers].hash}"
       if options[:method] == :get
         etag = @cache["etag:#{cache_key}"]

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -41,6 +41,17 @@ class ConfigurationTest < MiniTest::Unit::TestCase
     Heroics::Configuration.restore_defaults
   end
 
+  def test_configuring_status_codes
+    Heroics.default_configuration do |c|
+      c.acceptable_status_codes = [429]
+    end
+
+    assert(Heroics::Configuration.defaults.options[:status_codes].is_a?(Array))
+    assert_equal(Heroics::Configuration.defaults.options[:status_codes], [429])
+
+    Heroics::Configuration.restore_defaults
+  end
+
   def test_restore_defaults_class_method
     patterns = { /\W+/ => '-' }
     Heroics.default_configuration do |c|

--- a/test/link_test.rb
+++ b/test/link_test.rb
@@ -471,4 +471,19 @@ class LinkTest < MiniTest::Unit::TestCase
     assert_equal("Hello, world!\r\n", link.run)
     assert_equal(1, rate_throttle.call_count)
   end
+
+  def test_run_with_different_status_code
+    Excon.stub(method: :get) do |request|
+      assert_equal('/resource', request[:path])
+      Excon.stubs.pop
+      {status: 429, headers: {'Content-Type' => 'application/text'},
+       body: "Hello, world!\r\n"}
+    end
+    schema = Heroics::Schema.new(SAMPLE_SCHEMA)
+    link = Heroics::Link.new('https://example.com',
+                             schema.resource('resource').link('list'),
+                             { status_codes: [429] })
+
+    assert_equal("Hello, world!\r\n", link.run)
+  end
 end


### PR DESCRIPTION
When we're expecting the server to rate limit our client, then a different status code may be acceptable such as a 429. This PR introduces the ability to add additional acceptable status codes.