### PR TITLE
Fix bin/heroku-api

### DIFF
--- a/bin/heroku-api
+++ b/bin/heroku-api
@@ -2,6 +2,7 @@
 
 require 'heroics'
 require 'netrc'
+require 'moneta'
 
 netrc = Netrc.read
 username, token = netrc['api.heroku.com']


### PR DESCRIPTION
Currently when you try to run `bin/heroku-api` you get an error:

```
$ bundle exec bin/heroku-api
bundler: failed to load command: bin/heroku-api (bin/heroku-api)
NameError: uninitialized constant Moneta
  bin/heroku-api:12:in `<top (required)>'
```

This is happening because the `moneta` library is present but not required.

This PR fixes this issue by requiring the library.