### PR TITLE
Remove deprecations and warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@ require "rake/testtask"
 
 Rake::TestTask.new do |task|
   task.verbose = true
-  task.ruby_opts << '-r turn/autorun'
   task.ruby_opts << '-I test'
   task.test_files = FileList['test/**/*_test.rb', 'test/**/*_spec.rb']
 end

--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '4.7.5'
   spec.add_development_dependency 'netrc'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'turn'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'pry'
 

--- a/lib/heroics/schema.rb
+++ b/lib/heroics/schema.rb
@@ -244,7 +244,7 @@ module Heroics
                            [value['$ref'], key]
                          end]
       parameters.map do |parameter|
-        definition_name = URI.unescape(parameter[2..-3])
+        definition_name = ::URI::DEFAULT_PARSER.unescape(parameter[2..-3])
         if definitions.has_key?(definition_name)
           definitions[definition_name]
         else
@@ -273,7 +273,7 @@ module Heroics
     def resolve_parameter_details(parameters)
       parameters.map do |parameter|
         # URI decode parameters and strip the leading '{(' and trailing ')}'.
-        parameter = URI.unescape(parameter[2..-3])
+        parameter = ::URI::DEFAULT_PARSER.unescape(parameter[2..-3])
 
         # Split the path into components and discard the leading '#' that
         # represents the root of the schema.

--- a/test/client_generator_test.rb
+++ b/test/client_generator_test.rb
@@ -21,8 +21,6 @@ class GenerateClientTest  < MiniTest::Unit::TestCase
 
     default_headers =  {'Accept' => 'application/vnd.example+json; version=3'}
 
-    netrc = Netrc.read
-    username, token = netrc['example.com']
     schema_url = "https://example.com/schema"
     options = {
       default_headers: default_headers

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -257,7 +257,7 @@ class LinkSchemaTest < MiniTest::Unit::TestCase
 
   # LinkSchema.pretty_name returns the link name in a pretty form, with
   # underscores converted to dashes.
-  def test_pretty_resource_name
+  def test_pretty_name
     schema = Heroics::Schema.new(SAMPLE_SCHEMA)
     link = schema.resource('resource').link('identify_resource')
     assert_equal('identify-resource', link.pretty_name)


### PR DESCRIPTION
```
/Users/rschneeman/.gem/ruby/2.7.1/gems/heroics-0.1.1/lib/heroics/schema.rb:276: warning: URI.unescape is obsolete
/home/dcollispuro/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/heroics-0.0.21/lib/heroics/schema.rb:328:in 'format_parameter': warning: URI.escape is obsolete
```

Along with:

```
/Users/rschneeman/Documents/projects/tmp/heroics/test/client_generator_test.rb:25: warning: assigned but unused variable - username
/Users/rschneeman/Documents/projects/tmp/heroics/test/client_generator_test.rb:25: warning: assigned but unused variable - token
/Users/rschneeman/Documents/projects/tmp/heroics/test/schema_test.rb:260: warning: method redefined; discarding old test_pretty_resource_name
/Users/rschneeman/Documents/projects/tmp/heroics/test/schema_test.rb:252: warning: previous definition of test_pretty_resource_name was here
```

and

```
/Users/rschneeman/.gem/ruby/2.7.1/gems/turn-0.9.7/lib/turn/command.rb:289: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/rschneeman/.gem/ruby/2.7.1/gems/turn-0.9.7/lib/turn/colorize.rb:33: warning: instance variable @colorize not initialized
```