### PR TITLE
Add webrick as dependency since it's no longer bundled with Ruby >=3.0.0

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'excon'
   spec.add_dependency 'multi_json', '>= 1.9.2'
   spec.add_dependency 'moneta'
+  spec.add_dependency 'webrick'
 end


### PR DESCRIPTION
`webrick` is used [in `schema.rb`](https://github.com/interagent/heroics/blob/master/lib/heroics/schema.rb#L337), but [it is no longer included by default in Ruby >=3.0.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/), so it must be installed as an external gem.