### PR TITLE
remove erubis dependency

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'A Ruby client generator for HTTP APIs described with a JSON schema'
   spec.homepage      = 'https://github.com/interagent/heroics'
   spec.license       = 'MIT'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|example)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -27,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'erubis', '~> 2.0'
   spec.add_dependency 'excon'
   spec.add_dependency 'multi_json', '>= 1.9.2'
   spec.add_dependency 'moneta'

--- a/lib/heroics.rb
+++ b/lib/heroics.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 require 'base64'
-require 'erubis'
+require 'erb'
 require 'excon'
 require 'multi_json'
 require 'uri'

--- a/lib/heroics/client_generator.rb
+++ b/lib/heroics/client_generator.rb
@@ -4,12 +4,12 @@ module Heroics
   # option if you want to ship a gem or generate API documentation using Yard.
   def self.generate_client
     filename = File.dirname(__FILE__) + '/views/client.erb'
-    eruby = Erubis::Eruby.new(File.read(filename))
+    eruby = ERB.new(File.read(filename))
     context = build_context(Heroics::Configuration.defaults.module_name,
       Heroics::Configuration.defaults.schema,
       Heroics::Configuration.defaults.base_url,
       Heroics::Configuration.defaults.options)
-    eruby.evaluate(context)
+    eruby.result_with_hash(context)
   end
 
   private

--- a/lib/heroics/views/client.erb
+++ b/lib/heroics/views/client.erb
@@ -11,7 +11,7 @@ require 'heroics'
 require 'uri'
 require 'moneta'
 
-module <%= @module_name %>
+module <%= module_name %>
   # Get a Client configured to use HTTP Basic or header-based authentication.
   #
   # @param api_key [String] The API key to use when connecting.
@@ -75,7 +75,7 @@ module <%= @module_name %>
     if options[:default_headers]
       final_options[:default_headers].merge!(options[:default_headers])
     end
-    final_options[:cache] = options[:cache] || <%= @cache %>
+    final_options[:cache] = options[:cache] || <%= cache %>
     final_options[:url] = options[:url] if options[:url]
     final_options[:user] = options[:user] if options[:user]
     final_options
@@ -83,21 +83,21 @@ module <%= @module_name %>
 
   # Get the default options.
   def self.default_options
-    default_headers = <%= @default_headers %>
+    default_headers = <%= default_headers %>
     {
       default_headers: default_headers,
-      url:             "<%= @url %>"
+      url:             "<%= url %>"
     }
   end
 
   private_class_method :default_options, :custom_options
 
-  # <%= @description %>
+  # <%= description %>
   class Client
     def initialize(client)
       @client = client
     end
-    <% for resource in @resources %>
+    <% for resource in resources %>
 
     # <%= resource.description %>
     #
@@ -109,7 +109,7 @@ module <%= @module_name %>
   end
 
   private
-  <% for resource in @resources %>
+  <% for resource in resources %>
 
   # <%= resource.description %>
   class <%= resource.class_name %>
@@ -133,6 +133,6 @@ module <%= @module_name %>
   <% end %>
 
   SCHEMA = Heroics::Schema.new(MultiJson.load(<<-'HEROICS_SCHEMA'))
-<%= @schema %>
+<%= schema %>
 HEROICS_SCHEMA
 end


### PR DESCRIPTION
erubis hasn't been updated since 2011, and stdlib ERB is probably sufficient, so maybe it would be nice to remove this dependency.

AFAIK the template is not run often at runtime, so performance is not a concern. If it is, the erubi gem might be a good option. erubi would be preferable to erubis, because erubi is widely uses, including by rails.

tests pass with ruby 3, below. not sure if the test is comprehensive, maybe someone with some complicated use cases could stress test this as well.

result_with_hash became available in ruby 2.5, so i added that requirement. if we don't want to introduce that limitation, I also had a working version with this approach:

```ruby
    context.each do |k, v|
      instance_variable_set(:"@#{k}", v)
    end
    eruby.result(binding)
```

```
➔ bundle exec rake
/Users/john/.rbenv/versions/3.0.2/bin/ruby -w -I"lib" -I test /Users/john/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb "test/cli_test.rb" "test/client_generator_test.rb" "test/client_test.rb" "test/command_test.rb" "test/configuration_test.rb" "test/heroics_test.rb" "test/link_test.rb" "test/naming_test.rb" "test/resource_test.rb" "test/schema_test.rb" "test/version_test.rb"
Run options: --seed 34138

# Running tests:

............/Users/john/.rbenv/versions/3.0.2/lib/ruby/gems/3.0.0/gems/moneta-1.4.2/lib/moneta/transformer.rb:359: warning: too many arguments for format string
.....................................................................................................

Finished tests in 0.024013s, 4705.7844 tests/s, 12076.7917 assertions/s.

113 tests, 290 assertions, 0 failures, 0 errors, 0 skips
```