### PR TITLE
Add base64 dependency to gem spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+- Fix `base64` deprecation warning for Ruby 3.4 (https://github.com/interagent/heroics/pull/107)
+
 ## 0.1.2
 
 - Add support for Ruby 3.0 (https://github.com/interagent/heroics/pull/101)

--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json', '>= 1.9.2'
   spec.add_dependency 'moneta'
   spec.add_dependency 'webrick'
+  spec.add_dependency 'base64'
 end

--- a/lib/heroics/version.rb
+++ b/lib/heroics/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Heroics
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Eliminates deprecation warning for Ruby 3.4

Close #106