### PR TITLE
[changelog skip] Require MFA for all gem owners

### DIFF
--- a/heroics.gemspec
+++ b/heroics.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep('^(test|spec|features)/')
   spec.require_paths = ['lib']
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '4.7.5'


### PR DESCRIPTION
From https://guides.rubygems.org/mfa-requirement-opt-in/

> You can opt-in a gem you are managing by releasing a version that has metadata.rubygems_mfa_required set to true.
> ...
> The version being released with rubygems_mfa_required set and all the following versions will require you to have MFA enabled. Once enabled, the gem page will show NEW VERSIONS REQUIRE MFA in the sidebar, and all versions published with rubygems_mfa_required set will also show VERSION PUBLISHED WITH MFA: